### PR TITLE
Add unique identifier to Location class

### DIFF
--- a/src/main/java/seedu/address/commons/core/index/exceptions/InvalidIndexException.java
+++ b/src/main/java/seedu/address/commons/core/index/exceptions/InvalidIndexException.java
@@ -1,0 +1,10 @@
+package seedu.address.commons.core.index.exceptions;
+
+/**
+ * Signals that the operation will result in an invalid index.
+ */
+public class InvalidIndexException extends RuntimeException {
+    public InvalidIndexException() {
+        super("Operation would result in invalid index.");
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/AddLocationCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddLocationCommand.java
@@ -23,8 +23,6 @@ public class AddLocationCommand extends Command {
             + PREFIX_NAME + "School of Computing "
             + PREFIX_ADDRESS + "NUS School of Computing COM1 13 Computing Dr, 117417 ";
 
-    public static final String MESSAGE_NOT_IMPLEMENTED_YET = "Add location command not implemented yet";
-
     public static final String MESSAGE_SUCCESS = "New location added: %1$s";
     public static final String MESSAGE_DUPLICATE_LOCATION = "This location already exists in the virus tracker.";
 

--- a/src/main/java/seedu/address/model/location/Location.java
+++ b/src/main/java/seedu/address/model/location/Location.java
@@ -4,6 +4,7 @@ import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.util.Objects;
 
+import seedu.address.commons.core.index.Index;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Name;
 
@@ -13,19 +14,40 @@ import seedu.address.model.person.Name;
  */
 public class Location {
 
+    // Used to create unique identifiers for Locations by counting the number created
+    private static int locationCount = 1;
+
     // Identity fields
     private final Name name;
 
     // Data fields
     private final Address address;
+    private final Index id; // Id is not used when checking duplicates
 
     /**
-     * Every field must be present and not null.
+     * Every field must be present and not null. The Id is obtained from the class itself.
      */
     public Location(Name name, Address address) {
         requireAllNonNull(name, address);
         this.name = name;
         this.address = address;
+        this.id = Index.fromOneBased(locationCount);
+        locationCount += 1;
+    }
+
+    /**
+     * This constructor is used when creating copies of Locations due to edits or initialization.
+     */
+    public Location(Name name, Address address, Index id) {
+        requireAllNonNull(name, address, id);
+
+        // This update to location count is needed during initialization.
+        if (id.getOneBased() >= locationCount) {
+            locationCount = id.getOneBased() + 1;
+        }
+        this.name = name;
+        this.address = address;
+        this.id = id;
     }
 
     public Name getName() {
@@ -34,6 +56,10 @@ public class Location {
 
     public Address getAddress() {
         return address;
+    }
+
+    public Index getId() {
+        return id;
     }
 
     /**
@@ -65,13 +91,14 @@ public class Location {
 
         Location otherLocation = (Location) other;
         return otherLocation.getName().equals(getName())
-                && otherLocation.getAddress().equals(getAddress());
+                && otherLocation.getAddress().equals(getAddress())
+                && otherLocation.getId().equals(getId());
     }
 
     @Override
     public int hashCode() {
         // use this method for custom fields hashing instead of implementing your own
-        return Objects.hash(name, address);
+        return Objects.hash(name, address, id);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/location/Location.java
+++ b/src/main/java/seedu/address/model/location/Location.java
@@ -62,6 +62,11 @@ public class Location {
         return id;
     }
 
+    // for use in tests only
+    public static void setLocationCount(int count) {
+        locationCount = count;
+    }
+
     /**
      * Returns true if both locations have the same name.
      * This defines a weaker notion of equality between two locations.

--- a/src/main/java/seedu/address/model/location/Location.java
+++ b/src/main/java/seedu/address/model/location/Location.java
@@ -76,6 +76,17 @@ public class Location {
     }
 
     /**
+     * Returns true if both locations have the same id.
+     */
+    public boolean isSameId(Location otherLocation) {
+        if (otherLocation == this) {
+            return true;
+        }
+        return otherLocation != null
+                && otherLocation.getId().equals(getId());
+    }
+
+    /**
      * Returns true if both locations have the same identity and data fields.
      * This defines a stronger notion of equality between two locations.
      */

--- a/src/main/java/seedu/address/model/location/UniqueLocationList.java
+++ b/src/main/java/seedu/address/model/location/UniqueLocationList.java
@@ -10,6 +10,7 @@ import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import seedu.address.model.location.exceptions.DuplicateLocationException;
 import seedu.address.model.location.exceptions.LocationNotFoundException;
+import seedu.address.model.location.exceptions.LocationNotIdentifiableException;
 
 /**
  * A list of locations that enforces uniqueness between its elements and does not allow nulls.
@@ -30,6 +31,7 @@ public class UniqueLocationList implements Iterable<Location> {
 
     /**
      * Returns true if the list contains an equivalent location as the given argument.
+     * or if the location shares the same id as a location in the list.
      */
     public boolean contains(Location toCheck) {
         requireNonNull(toCheck);
@@ -37,13 +39,25 @@ public class UniqueLocationList implements Iterable<Location> {
     }
 
     /**
+     * Returns true if the list contains a location with the same id as the given argument.
+     */
+    public boolean containsSameIdLocation(Location toCheck) {
+        requireNonNull(toCheck);
+        return internalList.stream().anyMatch(toCheck::isSameId);
+    }
+
+    /**
      * Adds a location to the list.
      * The location must not already exist in the list.
+     * The location must not have same id as another location in the list.
      */
     public void add(Location toAdd) {
         requireNonNull(toAdd);
         if (contains(toAdd)) {
             throw new DuplicateLocationException();
+        }
+        if (containsSameIdLocation(toAdd)) {
+            throw new LocationNotIdentifiableException();
         }
         internalList.add(toAdd);
     }
@@ -64,6 +78,7 @@ public class UniqueLocationList implements Iterable<Location> {
         if (!target.isSameLocation(editedLocation) && contains(editedLocation)) {
             throw new DuplicateLocationException();
         }
+        assert(target.isSameId(editedLocation));
 
         internalList.set(index, editedLocation);
     }
@@ -92,6 +107,9 @@ public class UniqueLocationList implements Iterable<Location> {
         requireAllNonNull(locations);
         if (!locationsAreUnique(locations)) {
             throw new DuplicateLocationException();
+        }
+        if (!locationsAreIdentifiable(locations)) {
+            throw new LocationNotIdentifiableException();
         }
 
         internalList.setAll(locations);
@@ -128,6 +146,21 @@ public class UniqueLocationList implements Iterable<Location> {
         for (int i = 0; i < locations.size() - 1; i++) {
             for (int j = i + 1; j < locations.size(); j++) {
                 if (locations.get(i).isSameLocation(locations.get(j))) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Returns true if {@code locations} contains identifiable locations.
+     * This is true if all locations have different ids.
+     */
+    private boolean locationsAreIdentifiable(List<Location> locations) {
+        for (int i = 0; i < locations.size() - 1; i++) {
+            for (int j = i + 1; j < locations.size(); j++) {
+                if (locations.get(i).isSameId(locations.get(j))) {
                     return false;
                 }
             }

--- a/src/main/java/seedu/address/model/location/exceptions/LocationNotIdentifiableException.java
+++ b/src/main/java/seedu/address/model/location/exceptions/LocationNotIdentifiableException.java
@@ -1,0 +1,11 @@
+package seedu.address.model.location.exceptions;
+
+/**
+ * Signals that the operation will result in unidentifiable Locations (Locations are considered unidentifiable if they
+ * have the same id value).
+ */
+public class LocationNotIdentifiableException extends RuntimeException {
+    public LocationNotIdentifiableException() {
+        super("Operation would result in unidentifiable locations");
+    }
+}

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -54,9 +54,9 @@ public class SampleDataUtil {
     public static Location[] getSampleLocations() {
         return new Location[] {
             new Location(new Name("School of Computing"),
-                    new Address("NUS School of Computing COM1 13 Computing Dr, 117417")),
+                    new Address("NUS School of Computing COM1 13 Computing Dr, 117417"), Index.fromOneBased(1)),
             new Location(new Name("VivoCity"),
-                    new Address("1 HarbourFront Walk, Singapore 098585"))
+                    new Address("1 HarbourFront Walk, Singapore 098585"), Index.fromOneBased(2))
         };
     }
 

--- a/src/main/java/seedu/address/storage/JsonAdaptedLocation.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedLocation.java
@@ -65,15 +65,12 @@ public class JsonAdaptedLocation {
         if (id == null) {
             throw new IllegalValueException(MISSING_FIELD_MESSAGE_FORMAT);
         }
+        final Index modelId;
         try {
-            int i = Integer.parseInt(id);
-            if (i <= 0) {
-                throw new InvalidIndexException();
-            }
-        } catch (ClassCastException e) {
+            modelId = Index.fromOneBased(Integer.parseInt(id));
+        } catch (ClassCastException | IndexOutOfBoundsException e) {
             throw new InvalidIndexException();
         }
-        final Index modelId = Index.fromOneBased(Integer.parseInt(id));
 
         return new Location(modelName, modelAddress, modelId);
     }

--- a/src/main/java/seedu/address/storage/JsonAdaptedLocation.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedLocation.java
@@ -3,6 +3,8 @@ package seedu.address.storage;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import seedu.address.commons.core.index.Index;
+import seedu.address.commons.core.index.exceptions.InvalidIndexException;
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.location.Location;
 import seedu.address.model.person.Address;
@@ -16,14 +18,17 @@ public class JsonAdaptedLocation {
 
     private final String name;
     private final String address;
+    private final String id;
 
     /**
      * Constructs a {@code JsonAdaptedLocation} with the given location details.
      */
     @JsonCreator
-    public JsonAdaptedLocation(@JsonProperty("name") String name, @JsonProperty("address") String address) {
+    public JsonAdaptedLocation(@JsonProperty("name") String name, @JsonProperty("address") String address,
+                               @JsonProperty("id") String id) {
         this.name = name;
         this.address = address;
+        this.id = id;
     }
 
     /**
@@ -32,6 +37,7 @@ public class JsonAdaptedLocation {
     public JsonAdaptedLocation(Location source) {
         name = source.getName().fullName;
         address = source.getAddress().value;
+        id = source.getId().toString();
     }
 
     /**
@@ -56,6 +62,19 @@ public class JsonAdaptedLocation {
         }
         final Address modelAddress = new Address(address);
 
-        return new Location(modelName, modelAddress);
+        if (id == null) {
+            throw new IllegalValueException(MISSING_FIELD_MESSAGE_FORMAT);
+        }
+        try {
+            int i = Integer.parseInt(id);
+            if (i <= 0) {
+                throw new InvalidIndexException();
+            }
+        } catch (ClassCastException e) {
+            throw new InvalidIndexException();
+        }
+        final Index modelId = Index.fromOneBased(Integer.parseInt(id));
+
+        return new Location(modelName, modelAddress, modelId);
     }
 }

--- a/src/test/data/JsonLocationBookStorageTest/invalidAndValidLocationLocationBook.json
+++ b/src/test/data/JsonLocationBookStorageTest/invalidAndValidLocationLocationBook.json
@@ -1,9 +1,11 @@
 {
   "locations": [ {
     "name": "Valid Location",
-    "address": "4th street"
+    "address": "4th street",
+    "id": "1"
   }, {
     "name": "Location With Invalid Address Field",
-    "address": "   4th street"
+    "address": "   4th street",
+    "id": "0"
   } ]
 }

--- a/src/test/data/JsonLocationBookStorageTest/invalidLocationLocationBook.json
+++ b/src/test/data/JsonLocationBookStorageTest/invalidLocationLocationBook.json
@@ -1,6 +1,7 @@
 {
   "locations": [ {
     "name": "Location with invalid name field: Ha!ns Mu@ster",
-    "address": "4th street"
+    "address": "4th street",
+    "id": "1"
   } ]
 }

--- a/src/test/data/JsonSerializableLocationBookTest/duplicateLocationLocationBook.json
+++ b/src/test/data/JsonSerializableLocationBookTest/duplicateLocationLocationBook.json
@@ -1,9 +1,11 @@
 {
   "locations": [ {
     "name": "Esplanade",
-    "address": "123, Jurong West Ave 6, #08-111"
+    "address": "123, Jurong West Ave 6, #08-111",
+    "id": "1"
   }, {
     "name": "Esplanade",
-    "address": "4th street"
+    "address": "4th street",
+    "id": "1"
   } ]
 }

--- a/src/test/data/JsonSerializableLocationBookTest/invalidLocationLocationBook.json
+++ b/src/test/data/JsonSerializableLocationBookTest/invalidLocationLocationBook.json
@@ -1,6 +1,7 @@
 {
   "locations": [ {
     "name": "First Place",
-    "address": "  4th street"
+    "address": "  4th street",
+    "id": "-2"
   } ]
 }

--- a/src/test/data/JsonSerializableLocationBookTest/typicalLocationsLocationBook.json
+++ b/src/test/data/JsonSerializableLocationBookTest/typicalLocationsLocationBook.json
@@ -2,24 +2,31 @@
   "_comment": "LocationBook save file which contains the same Location values as in TypicalLocations#getTypicalLocationBook()",
   "locations" : [ {
     "name" : "Alice Pauline House",
-    "address" : "123, Jurong West Ave 6, #08-111"
+    "address" : "123, Jurong West Ave 6, #08-111",
+    "id": "2"
   }, {
     "name" : "Benson Meier House",
-    "address" : "311, Clementi Ave 2, #02-25"
+    "address" : "311, Clementi Ave 2, #02-25",
+    "id": "3"
   }, {
     "name" : "Carl Kurz House",
-    "address" : "wall street"
+    "address" : "wall street",
+    "id": "5"
   }, {
     "name" : "Daniel Meier House",
-    "address" : "10th street"
+    "address" : "10th street",
+    "id": "7"
   }, {
     "name" : "Elle Meyer House",
-    "address" : "michegan ave"
+    "address" : "michegan ave",
+    "id": "8"
   }, {
     "name" : "Fiona Kunz House",
-    "address" : "little tokyo"
+    "address" : "little tokyo",
+    "id": "10"
   }, {
     "name" : "George Best House",
-    "address" : "4th street"
+    "address" : "4th street",
+    "id": "6"
   } ]
 }

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -10,6 +10,8 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_QUARANTINE_STATUS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND;
+import static seedu.address.testutil.TypicalIndexes.INDEX_THIRD;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -42,6 +44,8 @@ public class CommandTestUtil {
     public static final String VALID_INFECTION_STATUS_BOB = "true";
     public static final String VALID_TAG_HUSBAND = "husband";
     public static final String VALID_TAG_FRIEND = "friend";
+    public static final Index VALID_ID_AMY_LOCATION = INDEX_SECOND;
+    public static final Index VALID_ID_BOB_LOCATION = INDEX_THIRD;
 
     public static final String NAME_DESC_AMY = " " + PREFIX_NAME + VALID_NAME_AMY;
     public static final String NAME_DESC_BOB = " " + PREFIX_NAME + VALID_NAME_BOB;
@@ -68,6 +72,7 @@ public class CommandTestUtil {
             + PREFIX_QUARANTINE_STATUS + "quarantined"; // only booleans allowed
     public static final String INVALID_INFECTION_DESC = " " + PREFIX_INFECTION + "nope"; // only true or false allowed
     public static final String INVALID_TAG_DESC = " " + PREFIX_TAG + "hubby*"; // '*' not allowed in tags
+    public static final String INVALID_ID_LOCATION = "-1";
 
     public static final String PREAMBLE_WHITESPACE = "\t  \r  \n";
     public static final String PREAMBLE_NON_EMPTY = "NonEmptyPreamble";

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -5,8 +5,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
-import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
-import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND;
 import static seedu.address.testutil.TypicalLocations.getTypicalLocationBook;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 import static seedu.address.testutil.TypicalVisits.getTypicalVisitBook;
@@ -31,8 +31,8 @@ public class DeleteCommandTest {
 
     @Test
     public void execute_validIndexUnfilteredList_success() {
-        Person personToDelete = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
-        DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_PERSON);
+        Person personToDelete = model.getFilteredPersonList().get(INDEX_FIRST.getZeroBased());
+        DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST);
 
         String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS, personToDelete);
 
@@ -53,10 +53,10 @@ public class DeleteCommandTest {
 
     @Test
     public void execute_validIndexFilteredList_success() {
-        showPersonAtIndex(model, INDEX_FIRST_PERSON);
+        showPersonAtIndex(model, INDEX_FIRST);
 
-        Person personToDelete = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
-        DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_PERSON);
+        Person personToDelete = model.getFilteredPersonList().get(INDEX_FIRST.getZeroBased());
+        DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST);
 
         String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS, personToDelete);
 
@@ -70,9 +70,9 @@ public class DeleteCommandTest {
 
     @Test
     public void execute_invalidIndexFilteredList_throwsCommandException() {
-        showPersonAtIndex(model, INDEX_FIRST_PERSON);
+        showPersonAtIndex(model, INDEX_FIRST);
 
-        Index outOfBoundIndex = INDEX_SECOND_PERSON;
+        Index outOfBoundIndex = INDEX_SECOND;
         // ensures that outOfBoundIndex is still in bounds of address book list
         assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getPersonList().size());
 
@@ -83,14 +83,14 @@ public class DeleteCommandTest {
 
     @Test
     public void equals() {
-        DeleteCommand deleteFirstCommand = new DeleteCommand(INDEX_FIRST_PERSON);
-        DeleteCommand deleteSecondCommand = new DeleteCommand(INDEX_SECOND_PERSON);
+        DeleteCommand deleteFirstCommand = new DeleteCommand(INDEX_FIRST);
+        DeleteCommand deleteSecondCommand = new DeleteCommand(INDEX_SECOND);
 
         // same object -> returns true
         assertTrue(deleteFirstCommand.equals(deleteFirstCommand));
 
         // same values -> returns true
-        DeleteCommand deleteFirstCommandCopy = new DeleteCommand(INDEX_FIRST_PERSON);
+        DeleteCommand deleteFirstCommandCopy = new DeleteCommand(INDEX_FIRST);
         assertTrue(deleteFirstCommand.equals(deleteFirstCommandCopy));
 
         // different types -> returns false

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -10,8 +10,8 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
-import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
-import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND;
 import static seedu.address.testutil.TypicalLocations.getTypicalLocationBook;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 import static seedu.address.testutil.TypicalVisits.getTypicalVisitBook;
@@ -42,7 +42,7 @@ public class EditCommandTest {
     public void execute_allFieldsSpecifiedUnfilteredList_success() {
         Person editedPerson = new PersonBuilder().build();
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(editedPerson).build();
-        EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON, descriptor);
+        EditCommand editCommand = new EditCommand(INDEX_FIRST, descriptor);
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, editedPerson);
 
@@ -77,8 +77,8 @@ public class EditCommandTest {
 
     @Test
     public void execute_noFieldSpecifiedUnfilteredList_success() {
-        EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON, new EditPersonDescriptor());
-        Person editedPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        EditCommand editCommand = new EditCommand(INDEX_FIRST, new EditPersonDescriptor());
+        Person editedPerson = model.getFilteredPersonList().get(INDEX_FIRST.getZeroBased());
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, editedPerson);
 
@@ -90,11 +90,11 @@ public class EditCommandTest {
 
     @Test
     public void execute_filteredList_success() {
-        showPersonAtIndex(model, INDEX_FIRST_PERSON);
+        showPersonAtIndex(model, INDEX_FIRST);
 
-        Person personInFilteredList = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Person personInFilteredList = model.getFilteredPersonList().get(INDEX_FIRST.getZeroBased());
         Person editedPerson = new PersonBuilder(personInFilteredList).withName(VALID_NAME_BOB).build();
-        EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON,
+        EditCommand editCommand = new EditCommand(INDEX_FIRST,
                 new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB).build());
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, editedPerson);
@@ -108,20 +108,20 @@ public class EditCommandTest {
 
     @Test
     public void execute_duplicatePersonUnfilteredList_failure() {
-        Person firstPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Person firstPerson = model.getFilteredPersonList().get(INDEX_FIRST.getZeroBased());
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(firstPerson).build();
-        EditCommand editCommand = new EditCommand(INDEX_SECOND_PERSON, descriptor);
+        EditCommand editCommand = new EditCommand(INDEX_SECOND, descriptor);
 
         assertCommandFailure(editCommand, model, EditCommand.MESSAGE_DUPLICATE_PERSON);
     }
 
     @Test
     public void execute_duplicatePersonFilteredList_failure() {
-        showPersonAtIndex(model, INDEX_FIRST_PERSON);
+        showPersonAtIndex(model, INDEX_FIRST);
 
         // edit person in filtered list into a duplicate in address book
-        Person personInList = model.getAddressBook().getPersonList().get(INDEX_SECOND_PERSON.getZeroBased());
-        EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON,
+        Person personInList = model.getAddressBook().getPersonList().get(INDEX_SECOND.getZeroBased());
+        EditCommand editCommand = new EditCommand(INDEX_FIRST,
                 new EditPersonDescriptorBuilder(personInList).build());
 
         assertCommandFailure(editCommand, model, EditCommand.MESSAGE_DUPLICATE_PERSON);
@@ -142,8 +142,8 @@ public class EditCommandTest {
      */
     @Test
     public void execute_invalidPersonIndexFilteredList_failure() {
-        showPersonAtIndex(model, INDEX_FIRST_PERSON);
-        Index outOfBoundIndex = INDEX_SECOND_PERSON;
+        showPersonAtIndex(model, INDEX_FIRST);
+        Index outOfBoundIndex = INDEX_SECOND;
         // ensures that outOfBoundIndex is still in bounds of address book list
         assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getPersonList().size());
 
@@ -155,11 +155,11 @@ public class EditCommandTest {
 
     @Test
     public void equals() {
-        final EditCommand standardCommand = new EditCommand(INDEX_FIRST_PERSON, DESC_AMY);
+        final EditCommand standardCommand = new EditCommand(INDEX_FIRST, DESC_AMY);
 
         // same values -> returns true
         EditPersonDescriptor copyDescriptor = new EditPersonDescriptor(DESC_AMY);
-        EditCommand commandWithSameValues = new EditCommand(INDEX_FIRST_PERSON, copyDescriptor);
+        EditCommand commandWithSameValues = new EditCommand(INDEX_FIRST, copyDescriptor);
         assertTrue(standardCommand.equals(commandWithSameValues));
 
         // same object -> returns true
@@ -172,10 +172,10 @@ public class EditCommandTest {
         assertFalse(standardCommand.equals(new ClearCommand()));
 
         // different index -> returns false
-        assertFalse(standardCommand.equals(new EditCommand(INDEX_SECOND_PERSON, DESC_AMY)));
+        assertFalse(standardCommand.equals(new EditCommand(INDEX_SECOND, DESC_AMY)));
 
         // different descriptor -> returns false
-        assertFalse(standardCommand.equals(new EditCommand(INDEX_FIRST_PERSON, DESC_BOB)));
+        assertFalse(standardCommand.equals(new EditCommand(INDEX_FIRST, DESC_BOB)));
     }
 
 }

--- a/src/test/java/seedu/address/logic/commands/ListCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListCommandTest.java
@@ -4,7 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
-import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST;
 import static seedu.address.testutil.TypicalLocations.getTypicalLocationBook;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 import static seedu.address.testutil.TypicalVisits.getTypicalVisitBook;
@@ -46,7 +46,7 @@ public class ListCommandTest {
 
     @Test
     public void execute_personsListIsFiltered_showsEverything() {
-        showPersonAtIndex(model, INDEX_FIRST_PERSON);
+        showPersonAtIndex(model, INDEX_FIRST);
         assertCommandSuccess(new ListCommand(PEOPLE_LIST),
                 model, ListCommand.MESSAGE_SUCCESS_ALL_PEOPLE, expectedModel);
     }

--- a/src/test/java/seedu/address/logic/parser/AddLocationCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddLocationCommandParserTest.java
@@ -30,14 +30,17 @@ public class AddLocationCommandParserTest {
     public void parse_allFieldsPresent_success() {
         Location expectedLocation = new LocationBuilder(BOB_LOCATION).build();
 
+        Location.setLocationCount(2);
         // whitespace only preamble
         assertParseSuccess(parser, PREAMBLE_WHITESPACE + NAME_DESC_BOB + ADDRESS_DESC_BOB,
                 new AddLocationCommand(expectedLocation));
 
+        Location.setLocationCount(2);
         // multiple names - last name accepted
         assertParseSuccess(parser, NAME_DESC_AMY + NAME_DESC_BOB + ADDRESS_DESC_BOB,
                 new AddLocationCommand(expectedLocation));
 
+        Location.setLocationCount(2);
         // multiple addresses - last address accepted
         assertParseSuccess(parser, NAME_DESC_BOB + ADDRESS_DESC_AMY + ADDRESS_DESC_BOB,
                 new AddLocationCommand(expectedLocation));

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -6,7 +6,7 @@ import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_LIST;
 import static seedu.address.testutil.Assert.assertThrows;
-import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST;
 
 import java.util.Arrays;
 import java.util.List;
@@ -48,6 +48,7 @@ public class AddressBookParserTest {
     @Test
     public void parseCommand_addLocation() throws Exception {
         Location location = new LocationBuilder().build();
+        Location.setLocationCount(1);
         AddLocationCommand command =
                 (AddLocationCommand) parser.parseCommand(LocationUtil.getAddLocationCommand(location));
         assertEquals(new AddLocationCommand(location), command);
@@ -62,8 +63,8 @@ public class AddressBookParserTest {
     @Test
     public void parseCommand_delete() throws Exception {
         DeleteCommand command = (DeleteCommand) parser.parseCommand(
-                DeleteCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased());
-        assertEquals(new DeleteCommand(INDEX_FIRST_PERSON), command);
+                DeleteCommand.COMMAND_WORD + " " + INDEX_FIRST.getOneBased());
+        assertEquals(new DeleteCommand(INDEX_FIRST), command);
     }
 
     @Test
@@ -71,8 +72,8 @@ public class AddressBookParserTest {
         Person person = new PersonBuilder().build();
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(person).build();
         EditCommand command = (EditCommand) parser.parseCommand(EditCommand.COMMAND_WORD + " "
-                + INDEX_FIRST_PERSON.getOneBased() + " " + PersonUtil.getEditPersonDescriptorDetails(descriptor));
-        assertEquals(new EditCommand(INDEX_FIRST_PERSON, descriptor), command);
+                + INDEX_FIRST.getOneBased() + " " + PersonUtil.getEditPersonDescriptorDetails(descriptor));
+        assertEquals(new EditCommand(INDEX_FIRST, descriptor), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
@@ -3,7 +3,7 @@ package seedu.address.logic.parser;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
-import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST;
 
 import org.junit.jupiter.api.Test;
 
@@ -22,7 +22,7 @@ public class DeleteCommandParserTest {
 
     @Test
     public void parse_validArgs_returnsDeleteCommand() {
-        assertParseSuccess(parser, "1", new DeleteCommand(INDEX_FIRST_PERSON));
+        assertParseSuccess(parser, "1", new DeleteCommand(INDEX_FIRST));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -37,9 +37,9 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
-import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
-import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
-import static seedu.address.testutil.TypicalIndexes.INDEX_THIRD_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND;
+import static seedu.address.testutil.TypicalIndexes.INDEX_THIRD;
 
 import org.junit.jupiter.api.Test;
 
@@ -123,7 +123,7 @@ public class EditCommandParserTest {
 
     @Test
     public void parse_allFieldsSpecified_success() {
-        Index targetIndex = INDEX_SECOND_PERSON;
+        Index targetIndex = INDEX_SECOND;
         String userInput = targetIndex.getOneBased() + PHONE_DESC_BOB + TAG_DESC_HUSBAND
                 + EMAIL_DESC_AMY + ADDRESS_DESC_AMY + NAME_DESC_AMY + TAG_DESC_FRIEND + QUARANTINE_STATUS_DESC_AMY
                 + INFECTION_DESC_AMY;
@@ -140,7 +140,7 @@ public class EditCommandParserTest {
 
     @Test
     public void parse_someFieldsSpecified_success() {
-        Index targetIndex = INDEX_FIRST_PERSON;
+        Index targetIndex = INDEX_FIRST;
         String userInput = targetIndex.getOneBased() + PHONE_DESC_BOB + EMAIL_DESC_AMY;
 
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withPhone(VALID_PHONE_BOB)
@@ -153,7 +153,7 @@ public class EditCommandParserTest {
     @Test
     public void parse_oneFieldSpecified_success() {
         // name
-        Index targetIndex = INDEX_THIRD_PERSON;
+        Index targetIndex = INDEX_THIRD;
         String userInput = targetIndex.getOneBased() + NAME_DESC_AMY;
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withName(VALID_NAME_AMY).build();
         EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
@@ -198,7 +198,7 @@ public class EditCommandParserTest {
 
     @Test
     public void parse_multipleRepeatedFields_acceptsLast() {
-        Index targetIndex = INDEX_FIRST_PERSON;
+        Index targetIndex = INDEX_FIRST;
         String userInput = targetIndex.getOneBased() + PHONE_DESC_AMY + ADDRESS_DESC_AMY + EMAIL_DESC_AMY
                 + QUARANTINE_STATUS_DESC_AMY + TAG_DESC_FRIEND + PHONE_DESC_AMY + ADDRESS_DESC_AMY + EMAIL_DESC_AMY
                 + QUARANTINE_STATUS_DESC_AMY + TAG_DESC_FRIEND + PHONE_DESC_BOB + ADDRESS_DESC_BOB + EMAIL_DESC_BOB
@@ -218,7 +218,7 @@ public class EditCommandParserTest {
     @Test
     public void parse_invalidValueFollowedByValidValue_success() {
         // no other valid values specified
-        Index targetIndex = INDEX_FIRST_PERSON;
+        Index targetIndex = INDEX_FIRST;
         String userInput = targetIndex.getOneBased() + INVALID_PHONE_DESC + PHONE_DESC_BOB;
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withPhone(VALID_PHONE_BOB).build();
         EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
@@ -235,7 +235,7 @@ public class EditCommandParserTest {
 
     @Test
     public void parse_resetTags_success() {
-        Index targetIndex = INDEX_THIRD_PERSON;
+        Index targetIndex = INDEX_THIRD;
         String userInput = targetIndex.getOneBased() + TAG_EMPTY;
 
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withTags().build();

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -4,7 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;
 import static seedu.address.testutil.Assert.assertThrows;
-import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -50,10 +50,10 @@ public class ParserUtilTest {
     @Test
     public void parseIndex_validInput_success() throws Exception {
         // No whitespaces
-        assertEquals(INDEX_FIRST_PERSON, ParserUtil.parseIndex("1"));
+        assertEquals(INDEX_FIRST, ParserUtil.parseIndex("1"));
 
         // Leading and trailing whitespaces
-        assertEquals(INDEX_FIRST_PERSON, ParserUtil.parseIndex("  1  "));
+        assertEquals(INDEX_FIRST, ParserUtil.parseIndex("  1  "));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/LocationBookTest.java
+++ b/src/test/java/seedu/address/model/LocationBookTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_ID_BOB_LOCATION;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalLocations.ALICE_LOCATION;
 import static seedu.address.testutil.TypicalLocations.getTypicalLocationBook;
@@ -44,7 +45,8 @@ public class LocationBookTest {
     @Test
     public void resetData_withDuplicateLocations_throwsDuplicateLocationException() {
         // Two locations with the same identity fields
-        Location editedAlice = new LocationBuilder(ALICE_LOCATION).withAddress(VALID_ADDRESS_BOB).build();
+        Location editedAlice = new LocationBuilder(ALICE_LOCATION).withAddress(VALID_ADDRESS_BOB)
+                .withId(VALID_ID_BOB_LOCATION).build();
         List<Location> newLocations = Arrays.asList(ALICE_LOCATION, editedAlice);
         LocationBookTest.LocationBookStub newData = new LocationBookTest.LocationBookStub(newLocations);
 
@@ -70,7 +72,8 @@ public class LocationBookTest {
     @Test
     public void hasLocation_locationWithSameIdentityFieldsInLocationBook_returnsTrue() {
         locationBook.addLocation(ALICE_LOCATION);
-        Location editedAlice = new LocationBuilder(ALICE_LOCATION).withAddress(VALID_ADDRESS_BOB).build();
+        Location editedAlice = new LocationBuilder(ALICE_LOCATION).withAddress(VALID_ADDRESS_BOB)
+                .withId(VALID_ID_BOB_LOCATION).build();
         assertTrue(locationBook.hasLocation(editedAlice));
     }
 

--- a/src/test/java/seedu/address/model/location/LocationTest.java
+++ b/src/test/java/seedu/address/model/location/LocationTest.java
@@ -3,6 +3,7 @@ package seedu.address.model.location;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_ID_BOB_LOCATION;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.testutil.TypicalLocations.ALICE_LOCATION;
 import static seedu.address.testutil.TypicalLocations.BOB_LOCATION;
@@ -30,6 +31,24 @@ public class LocationTest {
     }
 
     @Test
+    public void isSameId() {
+        // same object -> returns true
+        assertTrue(ALICE_LOCATION.isSameId(ALICE_LOCATION));
+
+        // null -> returns false
+        assertFalse(ALICE_LOCATION.isSameId(null));
+
+        // different id, same name, same address -> returns false
+        Location editedAlice = new LocationBuilder(ALICE_LOCATION).withId(VALID_ID_BOB_LOCATION).build();
+        assertFalse(ALICE_LOCATION.isSameId(editedAlice));
+
+        // same id, different name, different address -> returns true
+        editedAlice = new LocationBuilder(ALICE_LOCATION).withAddress(VALID_ADDRESS_BOB)
+                .withName(VALID_NAME_BOB).build();
+        assertTrue(ALICE_LOCATION.isSameId(editedAlice));
+    }
+
+    @Test
     public void equals() {
         // same values -> returns true
         Location aliceCopy = new LocationBuilder(ALICE_LOCATION).build();
@@ -53,6 +72,10 @@ public class LocationTest {
 
         // different address -> returns false
         editedAlice = new LocationBuilder(ALICE_LOCATION).withAddress(VALID_ADDRESS_BOB).build();
+        assertFalse(ALICE_LOCATION.equals(editedAlice));
+
+        // different id -> returns false
+        editedAlice = new LocationBuilder(ALICE_LOCATION).withId(VALID_ID_BOB_LOCATION).build();
         assertFalse(ALICE_LOCATION.equals(editedAlice));
     }
 }

--- a/src/test/java/seedu/address/model/location/UniqueLocationListTest.java
+++ b/src/test/java/seedu/address/model/location/UniqueLocationListTest.java
@@ -4,8 +4,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_ID_BOB_LOCATION;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalLocations.ALICE_LOCATION;
+import static seedu.address.testutil.TypicalLocations.AMY_LOCATION;
 import static seedu.address.testutil.TypicalLocations.BOB_LOCATION;
 
 import java.util.Arrays;
@@ -16,6 +19,7 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.model.location.exceptions.DuplicateLocationException;
 import seedu.address.model.location.exceptions.LocationNotFoundException;
+import seedu.address.model.location.exceptions.LocationNotIdentifiableException;
 import seedu.address.testutil.LocationBuilder;
 
 public class UniqueLocationListTest {
@@ -40,8 +44,34 @@ public class UniqueLocationListTest {
     @Test
     public void contains_locationWithSameIdentityFieldsInList_returnsTrue() {
         uniqueLocationList.add(ALICE_LOCATION);
-        Location editedAlice = new LocationBuilder(ALICE_LOCATION).withAddress(VALID_ADDRESS_BOB).build();
+        Location editedAlice = new LocationBuilder(ALICE_LOCATION).withAddress(VALID_ADDRESS_BOB)
+                .withId(VALID_ID_BOB_LOCATION).build();
         assertTrue(uniqueLocationList.contains(editedAlice));
+    }
+
+    @Test
+    public void containsSameIdLocation_nullLocation_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> uniqueLocationList.containsSameIdLocation(null));
+    }
+
+    @Test
+    public void containsSameIdLocation_locationNotInList_returnsFalse() {
+        assertFalse(uniqueLocationList.containsSameIdLocation(ALICE_LOCATION));
+    }
+
+    @Test
+    public void containsSameIdLocation_sameIdInList_returnsTrue() {
+        uniqueLocationList.add(ALICE_LOCATION);
+        Location editedAlice = new LocationBuilder(ALICE_LOCATION).withAddress(VALID_ADDRESS_BOB)
+                .withName(VALID_NAME_BOB).build();
+        assertTrue(uniqueLocationList.containsSameIdLocation(editedAlice));
+    }
+
+    @Test
+    public void containsSameIdLocation_sameIdentityDifferentId_returnsFalse() {
+        uniqueLocationList.add(ALICE_LOCATION);
+        Location editedAlice = new LocationBuilder(ALICE_LOCATION).withId(VALID_ID_BOB_LOCATION).build();
+        assertFalse(uniqueLocationList.containsSameIdLocation(editedAlice));
     }
 
     @Test
@@ -53,6 +83,14 @@ public class UniqueLocationListTest {
     public void add_duplicateLocation_throwsDuplicateLocationException() {
         uniqueLocationList.add(ALICE_LOCATION);
         assertThrows(DuplicateLocationException.class, () -> uniqueLocationList.add(ALICE_LOCATION));
+    }
+
+    @Test
+    public void add_unidentifiableLocation_throwsLocationNotIdentifiableException() {
+        uniqueLocationList.add(ALICE_LOCATION);
+        Location editedAlice = new LocationBuilder(ALICE_LOCATION).withAddress(VALID_ADDRESS_BOB)
+                .withName(VALID_NAME_BOB).build();
+        assertThrows(LocationNotIdentifiableException.class, () -> uniqueLocationList.add(editedAlice));
     }
 
     @Test
@@ -82,9 +120,9 @@ public class UniqueLocationListTest {
 
     @Test
     public void setLocation_editedLocationHasSameIdentity_success() {
-        uniqueLocationList.add(ALICE_LOCATION);
-        Location editedAlice = new LocationBuilder(ALICE_LOCATION).withAddress(VALID_ADDRESS_BOB).build();
-        uniqueLocationList.setLocation(ALICE_LOCATION, editedAlice);
+        Location editedAlice = new LocationBuilder(ALICE_LOCATION).withAddress(VALID_ADDRESS_BOB)
+                .withId(VALID_ID_BOB_LOCATION).build();
+        uniqueLocationList.add(editedAlice);
         UniqueLocationList expectedUniqueLocationList = new UniqueLocationList();
         expectedUniqueLocationList.add(editedAlice);
         assertEquals(expectedUniqueLocationList, uniqueLocationList);
@@ -101,10 +139,12 @@ public class UniqueLocationListTest {
 
     @Test
     public void setLocation_editedLocationHasNonUniqueIdentity_throwsDuplicateLocationException() {
-        uniqueLocationList.add(ALICE_LOCATION);
+        uniqueLocationList.add(AMY_LOCATION);
         uniqueLocationList.add(BOB_LOCATION);
+        Location editedAlice = new LocationBuilder(AMY_LOCATION).withAddress(VALID_ADDRESS_BOB)
+                .withName(VALID_NAME_BOB).build();
         assertThrows(DuplicateLocationException.class, () ->
-                uniqueLocationList.setLocation(ALICE_LOCATION, BOB_LOCATION));
+                uniqueLocationList.setLocation(AMY_LOCATION, editedAlice));
     }
 
     @Test
@@ -159,6 +199,15 @@ public class UniqueLocationListTest {
         List<Location> listWithDuplicateLocations = Arrays.asList(ALICE_LOCATION, ALICE_LOCATION);
         assertThrows(DuplicateLocationException.class, () ->
                 uniqueLocationList.setLocations(listWithDuplicateLocations));
+    }
+
+    @Test
+    public void setLocations_listWithUnidentifiableLocations_throwsDuplicateLocationException() {
+        Location editedAlice = new LocationBuilder(ALICE_LOCATION).withAddress(VALID_ADDRESS_BOB)
+                .withName(VALID_NAME_BOB).build();
+        List<Location> listWithUnidentifiableLocations = Arrays.asList(ALICE_LOCATION, editedAlice);
+        assertThrows(LocationNotIdentifiableException.class, () ->
+                uniqueLocationList.setLocations(listWithUnidentifiableLocations));
     }
 
     @Test

--- a/src/test/java/seedu/address/storage/JsonAdaptedLocationTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedLocationTest.java
@@ -7,6 +7,7 @@ import static seedu.address.testutil.TypicalLocations.BENSON_LOCATION;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.commons.core.index.exceptions.InvalidIndexException;
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Name;
@@ -14,9 +15,11 @@ import seedu.address.model.person.Name;
 public class JsonAdaptedLocationTest {
     private static final String INVALID_NAME = "R@chel";
     private static final String INVALID_ADDRESS = " ";
+    private static final String INVALID_ID = "0";
 
     private static final String VALID_NAME = BENSON_LOCATION.getName().toString();
     private static final String VALID_ADDRESS = BENSON_LOCATION.getAddress().toString();
+    private static final String VALID_ID = BENSON_LOCATION.getId().toString();
 
     @Test
     public void toModelType_validLocationDetails_returnsLocation() throws Exception {
@@ -27,14 +30,14 @@ public class JsonAdaptedLocationTest {
     @Test
     public void toModelType_invalidName_throwsIllegalValueException() {
         JsonAdaptedLocation location =
-                new JsonAdaptedLocation(INVALID_NAME, VALID_ADDRESS);
+                new JsonAdaptedLocation(INVALID_NAME, VALID_ADDRESS, VALID_ID);
         String expectedMessage = Name.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, location::toModelType);
     }
 
     @Test
     public void toModelType_nullName_throwsIllegalValueException() {
-        JsonAdaptedLocation location = new JsonAdaptedLocation(null, VALID_ADDRESS);
+        JsonAdaptedLocation location = new JsonAdaptedLocation(null, VALID_ADDRESS, VALID_ID);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, location::toModelType);
     }
@@ -42,15 +45,30 @@ public class JsonAdaptedLocationTest {
     @Test
     public void toModelType_invalidAddress_throwsIllegalValueException() {
         JsonAdaptedLocation location =
-                new JsonAdaptedLocation(VALID_NAME, INVALID_ADDRESS);
+                new JsonAdaptedLocation(VALID_NAME, INVALID_ADDRESS, VALID_ID);
         String expectedMessage = Address.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, location::toModelType);
     }
 
     @Test
     public void toModelType_nullAddress_throwsIllegalValueException() {
-        JsonAdaptedLocation location = new JsonAdaptedLocation(VALID_NAME, null);
+        JsonAdaptedLocation location = new JsonAdaptedLocation(VALID_NAME, null, VALID_ID);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Address.class.getSimpleName());
+        assertThrows(IllegalValueException.class, expectedMessage, location::toModelType);
+    }
+
+    @Test
+    public void toModelType_invalidId_throwsIllegalValueException() {
+        JsonAdaptedLocation location =
+                new JsonAdaptedLocation(VALID_NAME, VALID_ADDRESS, INVALID_ID);
+        String expectedMessage = new InvalidIndexException().getMessage();
+        assertThrows(InvalidIndexException.class, expectedMessage, location::toModelType);
+    }
+
+    @Test
+    public void toModelType_nullId_throwsIllegalValueException() {
+        JsonAdaptedLocation location = new JsonAdaptedLocation(VALID_NAME, VALID_ADDRESS, null);
+        String expectedMessage = MISSING_FIELD_MESSAGE_FORMAT;
         assertThrows(IllegalValueException.class, expectedMessage, location::toModelType);
     }
 }

--- a/src/test/java/seedu/address/testutil/LocationBuilder.java
+++ b/src/test/java/seedu/address/testutil/LocationBuilder.java
@@ -1,5 +1,6 @@
 package seedu.address.testutil;
 
+import seedu.address.commons.core.index.Index;
 import seedu.address.model.location.Location;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Name;
@@ -9,9 +10,11 @@ import seedu.address.model.person.Name;
 public class LocationBuilder {
     public static final String DEFAULT_NAME = "Vivocity";
     public static final String DEFAULT_ADDRESS = "123, Jurong West Ave 6, #08-111";
+    public static final String DEFAULT_ID = "1";
 
     private Name name;
     private Address address;
+    private Index id;
 
     /**
      * Creates a {@code LocationBuilder} with the default details.
@@ -19,6 +22,7 @@ public class LocationBuilder {
     public LocationBuilder() {
         name = new Name(DEFAULT_NAME);
         address = new Address(DEFAULT_ADDRESS);
+        id = Index.fromOneBased(Integer.parseInt(DEFAULT_ID));
     }
 
     /**
@@ -27,6 +31,7 @@ public class LocationBuilder {
     public LocationBuilder(Location locationToCopy) {
         name = locationToCopy.getName();
         address = locationToCopy.getAddress();
+        id = locationToCopy.getId();
     }
 
     /**
@@ -45,7 +50,15 @@ public class LocationBuilder {
         return this;
     }
 
+    /**
+     * Sets the Id of the {@code Location} that we are building.
+     */
+    public LocationBuilder withId(Index id) {
+        this.id = id;
+        return this;
+    }
+
     public Location build() {
-        return new Location(name, address);
+        return new Location(name, address, id);
     }
 }

--- a/src/test/java/seedu/address/testutil/TypicalIndexes.java
+++ b/src/test/java/seedu/address/testutil/TypicalIndexes.java
@@ -6,7 +6,14 @@ import seedu.address.commons.core.index.Index;
  * A utility class containing a list of {@code Index} objects to be used in tests.
  */
 public class TypicalIndexes {
-    public static final Index INDEX_FIRST_PERSON = Index.fromOneBased(1);
-    public static final Index INDEX_SECOND_PERSON = Index.fromOneBased(2);
-    public static final Index INDEX_THIRD_PERSON = Index.fromOneBased(3);
+    public static final Index INDEX_FIRST = Index.fromOneBased(1);
+    public static final Index INDEX_SECOND = Index.fromOneBased(2);
+    public static final Index INDEX_THIRD = Index.fromOneBased(3);
+    public static final Index INDEX_FOURTH = Index.fromOneBased(4);
+    public static final Index INDEX_FIFTH = Index.fromOneBased(5);
+    public static final Index INDEX_SIXTH = Index.fromOneBased(6);
+    public static final Index INDEX_SEVENTH = Index.fromOneBased(7);
+    public static final Index INDEX_EIGHTH = Index.fromOneBased(8);
+    public static final Index INDEX_NINTH = Index.fromOneBased(9);
+    public static final Index INDEX_TENTH = Index.fromOneBased(10);
 }

--- a/src/test/java/seedu/address/testutil/TypicalLocations.java
+++ b/src/test/java/seedu/address/testutil/TypicalLocations.java
@@ -4,6 +4,14 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
+import static seedu.address.testutil.TypicalIndexes.INDEX_EIGHTH;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIFTH;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SEVENTH;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SIXTH;
+import static seedu.address.testutil.TypicalIndexes.INDEX_TENTH;
+import static seedu.address.testutil.TypicalIndexes.INDEX_THIRD;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -17,31 +25,31 @@ import seedu.address.model.location.Location;
  */
 public class TypicalLocations {
     public static final Location ALICE_LOCATION = new LocationBuilder().withName("Alice Pauline House")
-            .withAddress("123, Jurong West Ave 6, #08-111").build();
+            .withAddress("123, Jurong West Ave 6, #08-111").withId(INDEX_SECOND).build();
     public static final Location BENSON_LOCATION = new LocationBuilder().withName("Benson Meier House")
-            .withAddress("311, Clementi Ave 2, #02-25").build();
+            .withAddress("311, Clementi Ave 2, #02-25").withId(INDEX_THIRD).build();
     public static final Location CARL_LOCATION = new LocationBuilder().withName("Carl Kurz House")
-            .withAddress("wall street").build();
+            .withAddress("wall street").withId(INDEX_FIFTH).build();
     public static final Location DANIEL_LOCATION = new LocationBuilder().withName("Daniel Meier House")
-            .withAddress("10th street").build();
+            .withAddress("10th street").withId(INDEX_SEVENTH).build();
     public static final Location ELLE_LOCATION = new LocationBuilder().withName("Elle Meyer House")
-            .withAddress("michegan ave").build();
+            .withAddress("michegan ave").withId(INDEX_EIGHTH).build();
     public static final Location FIONA_LOCATION = new LocationBuilder().withName("Fiona Kunz House")
-            .withAddress("little tokyo").build();
+            .withAddress("little tokyo").withId(INDEX_TENTH).build();
     public static final Location GEORGE_LOCATION = new LocationBuilder().withName("George Best House")
-            .withAddress("4th street").build();
+            .withAddress("4th street").withId(INDEX_SIXTH).build();
 
     // Manually added
     public static final Location HOON_LOCATION = new LocationBuilder().withName("Hoon Meier House")
-            .withAddress("little india").build();
+            .withAddress("little india").withId(INDEX_FIRST).build();
     public static final Location IDA_LOCATION = new LocationBuilder().withName("Ida Mueller House")
-            .withAddress("chicago ave").build();
+            .withAddress("chicago ave").withId(INDEX_SECOND).build();
 
     // Manually added - Location's details found in {@code CommandTestUtil}
     public static final Location AMY_LOCATION = new LocationBuilder().withName(VALID_NAME_AMY)
-            .withAddress(VALID_ADDRESS_AMY).build();
+            .withAddress(VALID_ADDRESS_AMY).withId(INDEX_FIRST).build();
     public static final Location BOB_LOCATION = new LocationBuilder().withName(VALID_NAME_BOB)
-            .withAddress(VALID_ADDRESS_BOB).build();
+            .withAddress(VALID_ADDRESS_BOB).withId(INDEX_SECOND).build();
 
     private TypicalLocations() {} // prevents instantiation
 


### PR DESCRIPTION
This Pull Request adds an Id field to the Location class. This is expected to be referenced by the Visit class when referring to the Location that a Person has visited. Id serves as a unique identifier for Locations. No two locations may have the same Id.  Unique identifiers are not exposed to the user. In addition, checks have been enforced within the UniqueLocationsList that no two locations within the list have the same Id.

Resolve #115 