### PR TITLE
Implement delete location functionality

### DIFF
--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -8,6 +8,7 @@ public class Messages {
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
+    public static final String MESSAGE_INVALID_LOCATION_DISPLAYED_INDEX = "The location index provided is invalid";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
 
 }

--- a/src/main/java/seedu/address/logic/commands/DeleteLocationCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteLocationCommand.java
@@ -1,0 +1,52 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.location.Location;
+
+/**
+ * Deletes a location identified using it's displayed index from the location book.
+ */
+public class DeleteLocationCommand extends Command {
+    public static final String COMMAND_WORD = "deleteLocation";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Deletes the location identified by the index number used in the displayed location list.\n"
+            + "Parameters: INDEX (must be a positive integer)\n"
+            + "Example: " + COMMAND_WORD + " 1";
+
+    public static final String MESSAGE_DELETE_LOCATION_SUCCESS = "Deleted Location: %1$s";
+
+    private final Index targetIndex;
+
+    public DeleteLocationCommand(Index targetIndex) {
+        this.targetIndex = targetIndex;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Location> lastShownList = model.getFilteredLocationList();
+
+        if (targetIndex.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        }
+
+        Location locationToDelete = lastShownList.get(targetIndex.getZeroBased());
+        model.deleteLocation(locationToDelete);
+        return new CommandResult(String.format(MESSAGE_DELETE_LOCATION_SUCCESS, locationToDelete));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof DeleteLocationCommand // instanceof handles nulls
+                && targetIndex.equals(((DeleteLocationCommand) other).targetIndex)); // state check
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/DeleteLocationCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteLocationCommand.java
@@ -35,7 +35,7 @@ public class DeleteLocationCommand extends Command {
         List<Location> lastShownList = model.getFilteredLocationList();
 
         if (targetIndex.getZeroBased() >= lastShownList.size()) {
-            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+            throw new CommandException(Messages.MESSAGE_INVALID_LOCATION_DISPLAYED_INDEX);
         }
 
         Location locationToDelete = lastShownList.get(targetIndex.getZeroBased());

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -12,6 +12,7 @@ import seedu.address.logic.commands.AddVisitCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteCommand;
+import seedu.address.logic.commands.DeleteLocationCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
@@ -57,6 +58,9 @@ public class AddressBookParser {
 
         case DeleteCommand.COMMAND_WORD:
             return new DeleteCommandParser().parse(arguments);
+
+        case DeleteLocationCommand.COMMAND_WORD:
+            return new DeleteLocationCommandParser().parse(arguments);
 
         case ClearCommand.COMMAND_WORD:
             return new ClearCommand();

--- a/src/main/java/seedu/address/logic/parser/DeleteLocationCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteLocationCommandParser.java
@@ -1,0 +1,30 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.DeleteLocationCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new DeleteLocationCommand object
+ */
+public class DeleteLocationCommandParser implements Parser<DeleteLocationCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the DeleteLocationCommand
+     * and returns a DeleteLocationCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    @Override
+    public DeleteLocationCommand parse(String args) throws ParseException {
+        try {
+            Index index = ParserUtil.parseIndex(args);
+            return new DeleteLocationCommand(index);
+        } catch (ParseException pe) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteLocationCommand.MESSAGE_USAGE), pe);
+        }
+
+    }
+}

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -123,6 +123,12 @@ public interface Model {
     void addLocation(Location location);
 
     /**
+     * Deletes the given location.
+     * The location must exist in the location book.
+     */
+    void deleteLocation(Location target);
+
+    /**
      * Returns true if a visit with the same identity as {@code visit} exists in the address book.
      */
     boolean hasVisit(Visit visit);

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -129,6 +129,14 @@ public interface Model {
     void deleteLocation(Location target);
 
     /**
+     * Replaces the given location {@code target} with {@code editedLocation}.
+     * {@code target} must exist in the location book.
+     * The location identity of {@code editedPerson} must not be the same as another existing location in the
+     * location book.
+     */
+    void setLocation(Location target, Location editedLocation);
+
+    /**
      * Returns true if a visit with the same identity as {@code visit} exists in the address book.
      */
     boolean hasVisit(Visit visit);

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -227,6 +227,10 @@ public class ModelManager implements Model {
         updateFilteredLocationList(PREDICATE_SHOW_ALL_LOCATIONS);
     }
 
+    @Override
+    public void deleteLocation(Location target) {
+        return;
+    }
 
 
     //=========== VisitBook ================================================================================

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -229,7 +229,13 @@ public class ModelManager implements Model {
 
     @Override
     public void deleteLocation(Location target) {
-        return;
+        locationBook.removeLocation(target);
+    }
+
+    @Override
+    public void setLocation(Location target, Location editedLocation) {
+        requireAllNonNull(target, editedLocation);
+        locationBook.setLocation(target, editedLocation);
     }
 
 

--- a/src/main/java/seedu/address/model/location/LocationNameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/location/LocationNameContainsKeywordsPredicate.java
@@ -1,0 +1,30 @@
+package seedu.address.model.location;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import seedu.address.commons.util.StringUtil;
+
+/**
+ * Tests that a {@code Location}'s {@code Name} matches any of the keywords given.
+ */
+public class LocationNameContainsKeywordsPredicate implements Predicate<Location> {
+    private final List<String> keywords;
+
+    public LocationNameContainsKeywordsPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(Location location) {
+        return keywords.stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(location.getName().fullName, keyword));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof LocationNameContainsKeywordsPredicate // instanceof handles nulls
+                && keywords.equals(((LocationNameContainsKeywordsPredicate) other).keywords)); // state check
+    }
+}

--- a/src/main/java/seedu/address/model/location/UniqueLocationList.java
+++ b/src/main/java/seedu/address/model/location/UniqueLocationList.java
@@ -14,6 +14,7 @@ import seedu.address.model.location.exceptions.LocationNotIdentifiableException;
 
 /**
  * A list of locations that enforces uniqueness between its elements and does not allow nulls.
+ * This list also enforces that all elements have unique ids.
  * A location is considered unique by comparing using {@code Location#isSameLocation(Location)}. As such, adding and
  * updating of locations uses Location#isSameLocation(Location) for equality so as to ensure that the location being
  * added or updated is unique in terms of identity in the UniqueLocationList. However, the removal of a location uses

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -198,6 +198,11 @@ public class AddCommandTest {
         }
 
         @Override
+        public void setLocation(Location target, Location editedLocation) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public boolean hasVisit(Visit visit) {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -193,6 +193,11 @@ public class AddCommandTest {
         }
 
         @Override
+        public void deleteLocation(Location target) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public boolean hasVisit(Visit visit) {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/address/logic/commands/AddLocationCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddLocationCommandTest.java
@@ -185,6 +185,11 @@ public class AddLocationCommandTest {
         }
 
         @Override
+        public void setLocation(Location target, Location editedLocation) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public boolean hasVisit(Visit visit) {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/address/logic/commands/AddLocationCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddLocationCommandTest.java
@@ -180,6 +180,11 @@ public class AddLocationCommandTest {
         }
 
         @Override
+        public void deleteLocation(Location target) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public boolean hasVisit(Visit visit) {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/address/logic/commands/AddVisitCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddVisitCommandTest.java
@@ -190,6 +190,11 @@ public class AddVisitCommandTest {
         }
 
         @Override
+        public void setLocation(Location target, Location editedLocation) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public ObservableList<Location> getFilteredLocationList() {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/address/logic/commands/AddVisitCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddVisitCommandTest.java
@@ -185,6 +185,11 @@ public class AddVisitCommandTest {
         }
 
         @Override
+        public void deleteLocation(Location target) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public ObservableList<Location> getFilteredLocationList() {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -21,6 +21,7 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
+import seedu.address.model.location.Location;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
@@ -146,5 +147,19 @@ public class CommandTestUtil {
         model.updateFilteredPersonList(new NameContainsKeywordsPredicate(Arrays.asList(splitName[0])));
 
         assertEquals(1, model.getFilteredPersonList().size());
+    }
+
+    /**
+     * Updates {@code model}'s filtered list to show only the location at the given {@code targetIndex} in the
+     * {@code model}'s location book.
+     */
+    public static void showLocationAtIndex(Model model, Index targetIndex) {
+        assertTrue(targetIndex.getZeroBased() < model.getFilteredLocationList().size());
+
+        Location location = model.getFilteredLocationList().get(targetIndex.getZeroBased());
+        final String[] splitName = location.getName().fullName.split("\\s+");
+        model.updateFilteredLocationList(new LocationNameContainsKeywordsPredicate(Arrays.asList(splitName[0])));
+
+        assertEquals(1, model.getFilteredLocationList().size());
     }
 }

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -22,6 +22,7 @@ import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.location.Location;
+import seedu.address.model.location.LocationNameContainsKeywordsPredicate;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
 import seedu.address.testutil.EditPersonDescriptorBuilder;

--- a/src/test/java/seedu/address/logic/commands/DeleteLocationCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteLocationCommandTest.java
@@ -1,0 +1,109 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.CommandTestUtil.showLocationAtIndex;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND;
+import static seedu.address.testutil.TypicalLocations.getTypicalLocationBook;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+import static seedu.address.testutil.TypicalVisits.getTypicalVisitBook;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.location.Location;
+
+public class DeleteLocationCommandTest {
+    private Model model = new ModelManager(getTypicalAddressBook(), getTypicalLocationBook(),
+            new UserPrefs(), getTypicalVisitBook());
+
+    @Test
+    public void execute_validIndexUnfilteredList_success() {
+        Location locationToDelete = model.getFilteredLocationList().get(INDEX_FIRST.getZeroBased());
+        DeleteLocationCommand deleteLocationCommand = new DeleteLocationCommand(INDEX_FIRST);
+
+        String expectedMessage = String.format(DeleteLocationCommand.MESSAGE_DELETE_LOCATION_SUCCESS, locationToDelete);
+
+        ModelManager expectedModel = new ModelManager(model.getAddressBook(), model.getLocationBook(),
+                new UserPrefs(), model.getVisitBook());
+        expectedModel.deleteLocation(locationToDelete);
+
+        assertCommandSuccess(deleteLocationCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidIndexUnfilteredList_throwsCommandException() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredLocationList().size() + 1);
+        DeleteLocationCommand deleteLocationCommand = new DeleteLocationCommand(outOfBoundIndex);
+
+        assertCommandFailure(deleteLocationCommand, model, Messages.MESSAGE_INVALID_LOCATION_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void execute_validIndexFilteredList_success() {
+        showLocationAtIndex(model, INDEX_FIRST);
+
+        Location locationToDelete = model.getFilteredLocationList().get(INDEX_FIRST.getZeroBased());
+        DeleteLocationCommand deleteLocationCommand = new DeleteLocationCommand(INDEX_FIRST);
+
+        String expectedMessage = String.format(DeleteLocationCommand.MESSAGE_DELETE_LOCATION_SUCCESS, locationToDelete);
+
+        Model expectedModel = new ModelManager(model.getAddressBook(), model.getLocationBook(),
+                new UserPrefs(), model.getVisitBook());
+        expectedModel.deleteLocation(locationToDelete);
+        showNoLocation(expectedModel);
+
+        assertCommandSuccess(deleteLocationCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidIndexFilteredList_throwsCommandException() {
+        showLocationAtIndex(model, INDEX_FIRST);
+
+        Index outOfBoundIndex = INDEX_SECOND;
+        // ensures that outOfBoundIndex is still in bounds of location book list
+        assertTrue(outOfBoundIndex.getZeroBased() < model.getLocationBook().getLocationList().size());
+
+        DeleteLocationCommand deleteLocationCommand = new DeleteLocationCommand(outOfBoundIndex);
+
+        assertCommandFailure(deleteLocationCommand, model, Messages.MESSAGE_INVALID_LOCATION_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void equals() {
+        DeleteLocationCommand deleteFirstCommand = new DeleteLocationCommand(INDEX_FIRST);
+        DeleteLocationCommand deleteSecondCommand = new DeleteLocationCommand(INDEX_SECOND);
+
+        // same object -> returns true
+        assertTrue(deleteFirstCommand.equals(deleteFirstCommand));
+
+        // same values -> returns true
+        DeleteLocationCommand deleteFirstCommandCopy = new DeleteLocationCommand(INDEX_FIRST);
+        assertTrue(deleteFirstCommand.equals(deleteFirstCommandCopy));
+
+        // different types -> returns false
+        assertFalse(deleteFirstCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(deleteFirstCommand.equals(null));
+
+        // different location -> returns false
+        assertFalse(deleteFirstCommand.equals(deleteSecondCommand));
+    }
+
+    /**
+     * Updates {@code model}'s filtered list to show no location.
+     */
+    private void showNoLocation(Model model) {
+        model.updateFilteredLocationList(p -> false);
+
+        assertTrue(model.getFilteredLocationList().isEmpty());
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -18,6 +18,7 @@ import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.AddLocationCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.DeleteCommand;
+import seedu.address.logic.commands.DeleteLocationCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
 import seedu.address.logic.commands.ExitCommand;
@@ -65,6 +66,13 @@ public class AddressBookParserTest {
         DeleteCommand command = (DeleteCommand) parser.parseCommand(
                 DeleteCommand.COMMAND_WORD + " " + INDEX_FIRST.getOneBased());
         assertEquals(new DeleteCommand(INDEX_FIRST), command);
+    }
+
+    @Test
+    public void parseCommand_deleteLocation() throws Exception {
+        DeleteLocationCommand command = (DeleteLocationCommand) parser.parseCommand(
+                DeleteLocationCommand.COMMAND_WORD + " " + INDEX_FIRST.getOneBased());
+        assertEquals(new DeleteLocationCommand(INDEX_FIRST), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/DeleteLocationCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteLocationCommandParserTest.java
@@ -1,0 +1,33 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.DeleteLocationCommand;
+
+/**
+ * As we are only doing white-box testing, our test cases do not cover path variations
+ * outside of the DeleteLocationCommand code. For example, inputs "1" and "1 abc" take the
+ * same path through the DeleteLocationCommand, and therefore we test only one of them.
+ * The path variation for those two cases occur inside the ParserUtil, and
+ * therefore should be covered by the ParserUtilTest.
+ */
+public class DeleteLocationCommandParserTest {
+
+    private DeleteLocationCommandParser parser = new DeleteLocationCommandParser();
+
+    @Test
+    public void parse_validArgs_returnsDeleteLocationCommand() {
+        assertParseSuccess(parser, "1", new DeleteLocationCommand(INDEX_FIRST));
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                DeleteLocationCommand.MESSAGE_USAGE));
+    }
+}

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -130,6 +130,11 @@ public class ModelManagerTest {
     }
 
     @Test
+    public void getFilteredLocationList_modifyList_throwsUnsupportedOperationException() {
+        assertThrows(UnsupportedOperationException.class, () -> modelManager.getFilteredLocationList().remove(0));
+    }
+
+    @Test
     public void setVisitBookFilePath_nullPath_throwsNullPointerException() {
         assertThrows(NullPointerException.class, () -> modelManager.setLocationBookFilePath(null));
     }

--- a/src/test/java/seedu/address/model/location/LocationNameContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/location/LocationNameContainsKeywordsPredicateTest.java
@@ -1,0 +1,79 @@
+package seedu.address.model.location;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.testutil.LocationBuilder;
+
+public class LocationNameContainsKeywordsPredicateTest {
+
+    @Test
+    public void equals() {
+        List<String> firstPredicateKeywordList = Collections.singletonList("first");
+        List<String> secondPredicateKeywordList = Arrays.asList("first", "second");
+
+        LocationNameContainsKeywordsPredicate firstPredicate =
+                new LocationNameContainsKeywordsPredicate(firstPredicateKeywordList);
+        LocationNameContainsKeywordsPredicate secondPredicate =
+                new LocationNameContainsKeywordsPredicate(secondPredicateKeywordList);
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same values -> returns true
+        LocationNameContainsKeywordsPredicate firstPredicateCopy =
+                new LocationNameContainsKeywordsPredicate(firstPredicateKeywordList);
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPredicate.equals(null));
+
+        // different person -> returns false
+        assertFalse(firstPredicate.equals(secondPredicate));
+    }
+
+    @Test
+    public void test_locationNameContainsKeywords_returnsTrue() {
+        // One keyword
+        LocationNameContainsKeywordsPredicate predicate =
+                new LocationNameContainsKeywordsPredicate(Collections.singletonList("Alice"));
+        assertTrue(predicate.test(new LocationBuilder().withName("Alice Bob").build()));
+
+        // Multiple keywords
+        predicate = new LocationNameContainsKeywordsPredicate(Arrays.asList("Alice", "Bob"));
+        assertTrue(predicate.test(new LocationBuilder().withName("Alice Bob").build()));
+
+        // Only one matching keyword
+        predicate = new LocationNameContainsKeywordsPredicate(Arrays.asList("Bob", "Carol"));
+        assertTrue(predicate.test(new LocationBuilder().withName("Alice Carol").build()));
+
+        // Mixed-case keywords
+        predicate = new LocationNameContainsKeywordsPredicate(Arrays.asList("aLIce", "bOB"));
+        assertTrue(predicate.test(new LocationBuilder().withName("Alice Bob").build()));
+    }
+
+    @Test
+    public void test_nameDoesNotContainKeywords_returnsFalse() {
+        // Zero keywords
+        LocationNameContainsKeywordsPredicate predicate =
+                new LocationNameContainsKeywordsPredicate(Collections.emptyList());
+        assertFalse(predicate.test(new LocationBuilder().withName("Alice").build()));
+
+        // Non-matching keyword
+        predicate = new LocationNameContainsKeywordsPredicate(Arrays.asList("Carol"));
+        assertFalse(predicate.test(new LocationBuilder().withName("Alice Bob").build()));
+
+        // Keywords match address, but does not match name
+        predicate = new LocationNameContainsKeywordsPredicate(Arrays.asList("Main", "Street"));
+        assertFalse(predicate.test(new LocationBuilder().withName("Alice").withAddress("Main Street").build()));
+    }
+}


### PR DESCRIPTION
The functionality to delete locations from location book has been implemented. Note that this implementation requires that any visits which are dependent on the location to be deleted, must be deleted first. A subsequent enhancement to delete visits that depend on the deleted location will be made in another pull request. 

Resolve #119