### PR TITLE
Add functionality for GUI list to match command type

### DIFF
--- a/src/main/java/seedu/address/logic/commands/CommandResult.java
+++ b/src/main/java/seedu/address/logic/commands/CommandResult.java
@@ -68,7 +68,8 @@ public class CommandResult {
         CommandResult otherCommandResult = (CommandResult) other;
         return feedbackToUser.equals(otherCommandResult.feedbackToUser)
                 && showHelp == otherCommandResult.showHelp
-                && exit == otherCommandResult.exit;
+                && exit == otherCommandResult.exit
+                && switchState.equals(otherCommandResult.switchState);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/location/AddLocationCommand.java
+++ b/src/main/java/seedu/address/logic/commands/location/AddLocationCommand.java
@@ -47,7 +47,8 @@ public class AddLocationCommand extends Command {
         }
 
         model.addLocation(toAdd);
-        return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd));
+        return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd), false, false,
+                CommandResult.SWITCH_TO_VIEW_LOCATIONS);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/location/DeleteLocationCommand.java
+++ b/src/main/java/seedu/address/logic/commands/location/DeleteLocationCommand.java
@@ -42,7 +42,8 @@ public class DeleteLocationCommand extends Command {
 
         Location locationToDelete = lastShownList.get(targetIndex.getZeroBased());
         model.deleteLocation(locationToDelete);
-        return new CommandResult(String.format(MESSAGE_DELETE_LOCATION_SUCCESS, locationToDelete));
+        return new CommandResult(String.format(MESSAGE_DELETE_LOCATION_SUCCESS, locationToDelete),
+                false, false, CommandResult.SWITCH_TO_VIEW_LOCATIONS);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/person/AddPersonCommand.java
+++ b/src/main/java/seedu/address/logic/commands/person/AddPersonCommand.java
@@ -63,7 +63,8 @@ public class AddPersonCommand extends Command {
         }
 
         model.addPerson(toAdd);
-        return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd));
+        return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd), false, false,
+                CommandResult.SWITCH_TO_VIEW_PEOPLE);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/person/DeletePersonCommand.java
+++ b/src/main/java/seedu/address/logic/commands/person/DeletePersonCommand.java
@@ -43,7 +43,8 @@ public class DeletePersonCommand extends Command {
 
         Person personToDelete = lastShownList.get(targetIndex.getZeroBased());
         model.deletePerson(personToDelete);
-        return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, personToDelete));
+        return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, personToDelete), false, false,
+                CommandResult.SWITCH_TO_VIEW_PEOPLE);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/person/EditPersonCommand.java
+++ b/src/main/java/seedu/address/logic/commands/person/EditPersonCommand.java
@@ -91,7 +91,8 @@ public class EditPersonCommand extends Command {
 
         model.setPerson(personToEdit, editedPerson);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
-        return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS, editedPerson));
+        return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS, editedPerson), false, false,
+                CommandResult.SWITCH_TO_VIEW_PEOPLE);
     }
 
     /**

--- a/src/main/java/seedu/address/logic/commands/person/FindPersonCommand.java
+++ b/src/main/java/seedu/address/logic/commands/person/FindPersonCommand.java
@@ -32,7 +32,8 @@ public class FindPersonCommand extends Command {
         requireNonNull(model);
         model.updateFilteredPersonList(predicate);
         return new CommandResult(
-                String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()));
+                String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()),
+                false, false, CommandResult.SWITCH_TO_VIEW_PEOPLE);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/visit/AddVisitCommand.java
+++ b/src/main/java/seedu/address/logic/commands/visit/AddVisitCommand.java
@@ -59,7 +59,8 @@ public class AddVisitCommand extends Command {
         }
 
         model.addVisit(visit);
-        return new CommandResult(String.format(MESSAGE_SUCCESS, visit));
+        return new CommandResult(String.format(MESSAGE_SUCCESS, visit), false, false,
+                CommandResult.SWITCH_TO_VIEW_VISITS);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/visit/DeleteVisitsCommand.java
+++ b/src/main/java/seedu/address/logic/commands/visit/DeleteVisitsCommand.java
@@ -73,7 +73,7 @@ public class DeleteVisitsCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         List<Visit> lastShownList = model.getFilteredVisitList();
         String result = deleteVisit(model, lastShownList, targetDate);
-        return new CommandResult(result);
+        return new CommandResult(result, false, false, CommandResult.SWITCH_TO_VIEW_VISITS);
     }
 
     @Override

--- a/src/test/java/seedu/address/logic/commands/GenerateLocationsCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/GenerateLocationsCommandTest.java
@@ -103,6 +103,8 @@ public class GenerateLocationsCommandTest {
         expectedModelForGenerate.updateFilteredLocationList(locationPredicate);
         Index index = Index.fromOneBased(4);
         GenerateLocationsCommand command = new GenerateLocationsCommand(index);
-        assertCommandSuccess(command, model, expectedMessage, expectedModelForGenerate);
+        CommandResult expectedCommandResult = new CommandResult(expectedMessage, false, false,
+                CommandResult.SWITCH_TO_VIEW_LOCATIONS);
+        assertCommandSuccess(command, model, expectedCommandResult, expectedModelForGenerate);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/GeneratePeopleCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/GeneratePeopleCommandTest.java
@@ -118,6 +118,8 @@ public class GeneratePeopleCommandTest {
         expectedModelForGenerate.updateFilteredPersonList(personPredicate);
         Index index = Index.fromOneBased(4);
         GeneratePeopleCommand command = new GeneratePeopleCommand(index);
-        assertCommandSuccess(command, model, expectedMessage, expectedModelForGenerate);
+        CommandResult expectedCommandResult = new CommandResult(expectedMessage, false, false,
+                CommandResult.SWITCH_TO_VIEW_PEOPLE);
+        assertCommandSuccess(command, model, expectedCommandResult, expectedModelForGenerate);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/ListCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListCommandTest.java
@@ -43,43 +43,55 @@ public class ListCommandTest {
 
     @Test
     public void execute_personsListIsNotFiltered_showsSameList() {
+        CommandResult expectedCommandResult = new CommandResult(ListCommand.MESSAGE_SUCCESS_ALL_PEOPLE, false, false,
+                CommandResult.SWITCH_TO_VIEW_PEOPLE);
         assertCommandSuccess(new ListCommand(PEOPLE_LIST),
-                model, ListCommand.MESSAGE_SUCCESS_ALL_PEOPLE, expectedModel);
+                model, expectedCommandResult, expectedModel);
     }
 
     @Test
     public void execute_personsListIsFiltered_showsEverything() {
         showPersonAtIndex(model, INDEX_FIRST);
+        CommandResult expectedCommandResult = new CommandResult(ListCommand.MESSAGE_SUCCESS_ALL_PEOPLE, false, false,
+                CommandResult.SWITCH_TO_VIEW_PEOPLE);
         assertCommandSuccess(new ListCommand(PEOPLE_LIST),
-                model, ListCommand.MESSAGE_SUCCESS_ALL_PEOPLE, expectedModel);
+                model, expectedCommandResult, expectedModel);
     }
 
     @Test
     public void execute_locationsList_showsSameList() {
+        CommandResult expectedCommandResult = new CommandResult(ListCommand.MESSAGE_SUCCESS_ALL_LOCATIONS, false, false,
+                CommandResult.SWITCH_TO_VIEW_LOCATIONS);
         assertCommandSuccess(new ListCommand(LOCATIONS_LIST),
-                model, ListCommand.MESSAGE_SUCCESS_ALL_LOCATIONS, expectedModel);
+                model, expectedCommandResult, expectedModel);
     }
 
     @Test
     public void execute_visitsList_showsSameList() {
+        CommandResult expectedCommandResult = new CommandResult(ListCommand.MESSAGE_SUCCESS_ALL_VISITS, false, false,
+                CommandResult.SWITCH_TO_VIEW_VISITS);
         assertCommandSuccess(new ListCommand(VISITS_LIST),
-                model, ListCommand.MESSAGE_SUCCESS_ALL_VISITS, expectedModel);
+                model, expectedCommandResult, expectedModel);
     }
 
     @Test
     public void execute_infectedList_showsSameList() {
         Model expectedModelInfected = expectedModel;
         expectedModelInfected.updateFilteredPersonList(ModelPredicate.PREDICATE_SHOW_ALL_INFECTED);
+        CommandResult expectedCommandResult = new CommandResult(ListCommand.MESSAGE_SUCCESS_ALL_INFECTED, false, false,
+                CommandResult.SWITCH_TO_VIEW_PEOPLE);
         assertCommandSuccess(new ListCommand(INFECTED_LIST),
-                model, ListCommand.MESSAGE_SUCCESS_ALL_INFECTED, expectedModelInfected);
+                model, expectedCommandResult, expectedModelInfected);
     }
 
     @Test
     public void execute_quarantinedList_showsSameList() {
         Model expectedModelQuarantined = expectedModel;
         expectedModelQuarantined.updateFilteredPersonList(ModelPredicate.PREDICATE_SHOW_ALL_QUARANTINED);
+        CommandResult expectedCommandResult = new CommandResult(ListCommand.MESSAGE_SUCCESS_ALL_QUARANTINED,
+                false, false, CommandResult.SWITCH_TO_VIEW_PEOPLE);
         assertCommandSuccess(new ListCommand(QUARANTINED_LIST),
-                model, ListCommand.MESSAGE_SUCCESS_ALL_QUARANTINED, expectedModelQuarantined);
+                model, expectedCommandResult, expectedModelQuarantined);
     }
 
     @Test
@@ -101,8 +113,10 @@ public class ListCommandTest {
         Model expectedModelHighRiskLocations = expectedModel;
         expectedModelHighRiskLocations.updateFilteredLocationList(
                 ModelPredicate.getPredicateForHighRiskLocations(expectedModelHighRiskLocations));
+        CommandResult expectedCommandResult = new CommandResult(ListCommand.MESSAGE_SUCCESS_HIGH_RISK_LOCATIONS,
+                false, false, CommandResult.SWITCH_TO_VIEW_LOCATIONS);
         assertCommandSuccess(new ListCommand(HIGH_RISK_LOCATIONS_LIST),
-                model, ListCommand.MESSAGE_SUCCESS_HIGH_RISK_LOCATIONS, expectedModelHighRiskLocations);
+                model, expectedCommandResult, expectedModelHighRiskLocations);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/location/DeleteLocationCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/location/DeleteLocationCommandTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.CommandResult;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
@@ -34,8 +35,10 @@ public class DeleteLocationCommandTest {
         ModelManager expectedModel = new ModelManager(model.getPersonBook(), model.getLocationBook(),
                 model.getVisitBook(), new UserPrefs());
         expectedModel.deleteLocation(locationToDelete);
+        CommandResult expectedCommandResult = new CommandResult(expectedMessage, false, false,
+                CommandResult.SWITCH_TO_VIEW_LOCATIONS);
 
-        assertCommandSuccess(deleteLocationCommand, model, expectedMessage, expectedModel);
+        assertCommandSuccess(deleteLocationCommand, model, expectedCommandResult, expectedModel);
     }
 
     @Test
@@ -59,8 +62,10 @@ public class DeleteLocationCommandTest {
                 model.getVisitBook(), new UserPrefs());
         expectedModel.deleteLocation(locationToDelete);
         showNoLocation(expectedModel);
+        CommandResult expectedCommandResult = new CommandResult(expectedMessage, false, false,
+                CommandResult.SWITCH_TO_VIEW_LOCATIONS);
 
-        assertCommandSuccess(deleteLocationCommand, model, expectedMessage, expectedModel);
+        assertCommandSuccess(deleteLocationCommand, model, expectedCommandResult, expectedModel);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/location/EditLocationCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/location/EditLocationCommandTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.Test;
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.ClearCommand;
+import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.location.EditLocationCommand.EditLocationDescriptor;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
@@ -48,8 +49,10 @@ class EditLocationCommandTest {
         Model expectedModel = new ModelManager(new PersonBook(model.getPersonBook()),
                 new LocationBook(model.getLocationBook()), new VisitBook(model.getVisitBook()), new UserPrefs());
         expectedModel.setLocation(model.getFilteredLocationList().get(0), editedLocation);
+        CommandResult expectedCommandResult = new CommandResult(expectedMessage, false, false,
+                CommandResult.SWITCH_TO_VIEW_LOCATIONS);
 
-        assertCommandSuccess(editLocationCommand, model, expectedMessage, expectedModel);
+        assertCommandSuccess(editLocationCommand, model, expectedCommandResult, expectedModel);
     }
 
     @Test
@@ -68,8 +71,10 @@ class EditLocationCommandTest {
         Model expectedModel = new ModelManager(new PersonBook(model.getPersonBook()),
                 new LocationBook(model.getLocationBook()), new VisitBook(model.getVisitBook()), new UserPrefs());
         expectedModel.setLocation(lastLocation, editedLocation);
+        CommandResult expectedCommandResult = new CommandResult(expectedMessage, false, false,
+                CommandResult.SWITCH_TO_VIEW_LOCATIONS);
 
-        assertCommandSuccess(editLocationCommand, model, expectedMessage, expectedModel);
+        assertCommandSuccess(editLocationCommand, model, expectedCommandResult, expectedModel);
     }
 
     @Test
@@ -82,8 +87,10 @@ class EditLocationCommandTest {
 
         Model expectedModel = new ModelManager(new PersonBook(model.getPersonBook()),
                 new LocationBook(model.getLocationBook()), new VisitBook(model.getVisitBook()), new UserPrefs());
+        CommandResult expectedCommandResult = new CommandResult(expectedMessage, false, false,
+                CommandResult.SWITCH_TO_VIEW_LOCATIONS);
 
-        assertCommandSuccess(editLocationCommand, model, expectedMessage, expectedModel);
+        assertCommandSuccess(editLocationCommand, model, expectedCommandResult, expectedModel);
     }
 
     @Test
@@ -100,8 +107,10 @@ class EditLocationCommandTest {
         Model expectedModel = new ModelManager(new PersonBook(model.getPersonBook()),
                 new LocationBook(model.getLocationBook()), new VisitBook(model.getVisitBook()), new UserPrefs());
         expectedModel.setLocation(model.getFilteredLocationList().get(0), editedLocation);
+        CommandResult expectedCommandResult = new CommandResult(expectedMessage, false, false,
+                CommandResult.SWITCH_TO_VIEW_LOCATIONS);
 
-        assertCommandSuccess(editLocationCommand, model, expectedMessage, expectedModel);
+        assertCommandSuccess(editLocationCommand, model, expectedCommandResult, expectedModel);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/person/AddPersonCommandIntegrationTest.java
+++ b/src/test/java/seedu/address/logic/commands/person/AddPersonCommandIntegrationTest.java
@@ -9,6 +9,7 @@ import static seedu.address.testutil.TypicalVisits.getTypicalVisitBook;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import seedu.address.logic.commands.CommandResult;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
@@ -35,9 +36,11 @@ public class AddPersonCommandIntegrationTest {
         Model expectedModel = new ModelManager(model.getPersonBook(), model.getLocationBook(),
                 model.getVisitBook(), new UserPrefs());
         expectedModel.addPerson(validPerson);
+        String expectedMessage = String.format(AddPersonCommand.MESSAGE_SUCCESS, validPerson);
+        CommandResult expectedCommandResult = new CommandResult(expectedMessage, false, false,
+                CommandResult.SWITCH_TO_VIEW_PEOPLE);
 
-        assertCommandSuccess(new AddPersonCommand(validPerson), model,
-                String.format(AddPersonCommand.MESSAGE_SUCCESS, validPerson), expectedModel);
+        assertCommandSuccess(new AddPersonCommand(validPerson), model, expectedCommandResult, expectedModel);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/person/DeletePersonCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/person/DeletePersonCommandTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.CommandResult;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
@@ -39,8 +40,10 @@ public class DeletePersonCommandTest {
         ModelManager expectedModel = new ModelManager(model.getPersonBook(), model.getLocationBook(),
                 model.getVisitBook(), new UserPrefs());
         expectedModel.deletePerson(personToDelete);
+        CommandResult expectedCommandResult = new CommandResult(expectedMessage, false, false,
+                CommandResult.SWITCH_TO_VIEW_PEOPLE);
 
-        assertCommandSuccess(deletePersonCommand, model, expectedMessage, expectedModel);
+        assertCommandSuccess(deletePersonCommand, model, expectedCommandResult, expectedModel);
     }
 
     @Test
@@ -64,8 +67,10 @@ public class DeletePersonCommandTest {
                 model.getVisitBook(), new UserPrefs());
         expectedModel.deletePerson(personToDelete);
         showNoPerson(expectedModel);
+        CommandResult expectedCommandResult = new CommandResult(expectedMessage, false, false,
+                CommandResult.SWITCH_TO_VIEW_PEOPLE);
 
-        assertCommandSuccess(deletePersonCommand, model, expectedMessage, expectedModel);
+        assertCommandSuccess(deletePersonCommand, model, expectedCommandResult, expectedModel);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/person/EditPersonCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/person/EditPersonCommandTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.ClearCommand;
+import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.person.EditPersonCommand.EditPersonDescriptor;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
@@ -51,8 +52,9 @@ public class EditPersonCommandTest {
         Model expectedModel = new ModelManager(new PersonBook(model.getPersonBook()),
                 new LocationBook(model.getLocationBook()), new VisitBook(model.getVisitBook()), new UserPrefs());
         expectedModel.setPerson(model.getFilteredPersonList().get(0), editedPerson);
-
-        assertCommandSuccess(editPersonCommand, model, expectedMessage, expectedModel);
+        CommandResult expectedCommandResult = new CommandResult(expectedMessage, false, false,
+                CommandResult.SWITCH_TO_VIEW_PEOPLE);
+        assertCommandSuccess(editPersonCommand, model, expectedCommandResult, expectedModel);
     }
 
     @Test
@@ -73,8 +75,10 @@ public class EditPersonCommandTest {
         Model expectedModel = new ModelManager(new PersonBook(model.getPersonBook()),
                 new LocationBook(model.getLocationBook()), new VisitBook(model.getVisitBook()), new UserPrefs());
         expectedModel.setPerson(lastPerson, editedPerson);
+        CommandResult expectedCommandResult = new CommandResult(expectedMessage, false, false,
+                CommandResult.SWITCH_TO_VIEW_PEOPLE);
 
-        assertCommandSuccess(editPersonCommand, model, expectedMessage, expectedModel);
+        assertCommandSuccess(editPersonCommand, model, expectedCommandResult, expectedModel);
     }
 
     @Test
@@ -86,8 +90,10 @@ public class EditPersonCommandTest {
 
         Model expectedModel = new ModelManager(new PersonBook(model.getPersonBook()),
                 new LocationBook(model.getLocationBook()), new VisitBook(model.getVisitBook()), new UserPrefs());
+        CommandResult expectedCommandResult = new CommandResult(expectedMessage, false, false,
+                CommandResult.SWITCH_TO_VIEW_PEOPLE);
 
-        assertCommandSuccess(editPersonCommand, model, expectedMessage, expectedModel);
+        assertCommandSuccess(editPersonCommand, model, expectedCommandResult, expectedModel);
     }
 
     @Test
@@ -104,8 +110,10 @@ public class EditPersonCommandTest {
         Model expectedModel = new ModelManager(new PersonBook(model.getPersonBook()),
                 new LocationBook(model.getLocationBook()), new VisitBook(model.getVisitBook()), new UserPrefs());
         expectedModel.setPerson(model.getFilteredPersonList().get(0), editedPerson);
+        CommandResult expectedCommandResult = new CommandResult(expectedMessage, false, false,
+                CommandResult.SWITCH_TO_VIEW_PEOPLE);
 
-        assertCommandSuccess(editPersonCommand, model, expectedMessage, expectedModel);
+        assertCommandSuccess(editPersonCommand, model, expectedCommandResult, expectedModel);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/person/FindPersonCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/person/FindPersonCommandTest.java
@@ -17,6 +17,7 @@ import java.util.Collections;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.logic.commands.CommandResult;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
@@ -64,7 +65,9 @@ public class FindPersonCommandTest {
         NameContainsKeywordsPredicate predicate = preparePredicate(" ");
         FindPersonCommand command = new FindPersonCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
-        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        CommandResult expectedCommandResult = new CommandResult(expectedMessage, false, false,
+                CommandResult.SWITCH_TO_VIEW_PEOPLE);
+        assertCommandSuccess(command, model, expectedCommandResult, expectedModel);
         assertEquals(Collections.emptyList(), model.getFilteredPersonList());
     }
 
@@ -74,7 +77,9 @@ public class FindPersonCommandTest {
         NameContainsKeywordsPredicate predicate = preparePredicate("Kurz Elle Kunz");
         FindPersonCommand command = new FindPersonCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
-        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        CommandResult expectedCommandResult = new CommandResult(expectedMessage, false, false,
+                CommandResult.SWITCH_TO_VIEW_PEOPLE);
+        assertCommandSuccess(command, model, expectedCommandResult, expectedModel);
         assertEquals(Arrays.asList(CARL, ELLE, FIONA), model.getFilteredPersonList());
     }
 

--- a/src/test/java/seedu/address/logic/commands/visit/AddVisitCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/visit/AddVisitCommandTest.java
@@ -62,6 +62,7 @@ public class AddVisitCommandTest {
             assertEquals(String.format(AddVisitCommand.MESSAGE_SUCCESS, validVisit),
                     commandResult.getFeedbackToUser());
             assertEquals(Arrays.asList(validVisit), modelStub.visitsAdded);
+            assertEquals(commandResult.getSwitchState(), CommandResult.SWITCH_TO_VIEW_VISITS);
         } catch (CommandException e) {
             assert false : "Command Exception not expected.";
         }
@@ -83,8 +84,9 @@ public class AddVisitCommandTest {
                 .build();
 
         try {
-            new AddVisitCommand(INDEX_FIRST, INDEX_FIRST, DEFAULT_DATE).execute(model);
+            CommandResult commandResult = new AddVisitCommand(INDEX_FIRST, INDEX_FIRST, DEFAULT_DATE).execute(model);
             assertEquals(model.getFilteredVisitList().get(0), validVisit);
+            assertEquals(commandResult.getSwitchState(), CommandResult.SWITCH_TO_VIEW_VISITS);
         } catch (CommandException e) {
             assert false : "Command Exception not expected.";
         }

--- a/src/test/java/seedu/address/logic/commands/visit/DeleteVisitsCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/visit/DeleteVisitsCommandTest.java
@@ -16,6 +16,7 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.logic.commands.CommandResult;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
@@ -54,8 +55,9 @@ public class DeleteVisitsCommandTest {
         expectedModel.deleteVisit(visits.get(3));
 
         String expectedResult = expectedMessage.toString();
-
-        assertCommandSuccess(deleteVisitsCommand, model, expectedResult, expectedModel);
+        CommandResult expectedCommandResult = new CommandResult(expectedResult, false, false,
+                CommandResult.SWITCH_TO_VIEW_VISITS);
+        assertCommandSuccess(deleteVisitsCommand, model, expectedCommandResult, expectedModel);
     }
 
     @Test
@@ -93,7 +95,9 @@ public class DeleteVisitsCommandTest {
 
         showNoVisit(expectedModel);
 
-        assertCommandSuccess(deleteVisitsCommand, model, expectedResult, expectedModel);
+        CommandResult expectedCommandResult = new CommandResult(expectedResult, false, false,
+                CommandResult.SWITCH_TO_VIEW_VISITS);
+        assertCommandSuccess(deleteVisitsCommand, model, expectedCommandResult, expectedModel);
     }
 
     @Test


### PR DESCRIPTION
When VirusTracker was an address book, the list was always displaying person panels. However, VirusTracker can now display 3 separate lists for person, visit and location. VirusTracker thus needs to be updated to ensure the right list is being displayed after each command. 

Locations should be displayed after location commands are executed.
People should be displayed after person commands are executed.
Visits should be displayed after visit commands are executed.

Fix #140 