### PR TITLE
Include assert in generatePeople

### DIFF
--- a/src/main/java/seedu/address/logic/commands/GeneratePeopleCommand.java
+++ b/src/main/java/seedu/address/logic/commands/GeneratePeopleCommand.java
@@ -61,6 +61,7 @@ public class GeneratePeopleCommand extends Command {
         if (personIds.isEmpty()) {
             throw new CommandException(MESSAGE_NO_PEOPLE_FOUND);
         }
+        assert !personIds.isEmpty();
         model.updateFilteredPersonList(ModelPredicate.getPredicateShowPeopleById(personIds));
         return new CommandResult(
                 "Generated people for: " + infectedPerson.getName());


### PR DESCRIPTION
Assert has been added to ensure that the list of personIds used to update the FilteredPersonList is not empty.